### PR TITLE
Fix --inline and add an --inline example to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ It should run on any Unix OS. If you notice any problems let me know.
 
   Set the background to a specific colour:  
   `cecho --background=170 "string to echo"`
+
+  Set foreground to red and center in terminal.
+  `cecho --centre --red "string to echo"`

--- a/README.md
+++ b/README.md
@@ -67,3 +67,6 @@ It should run on any Unix OS. If you notice any problems let me know.
 
   Set foreground to red and center in terminal.
   `cecho --centre --red "string to echo"`
+
+  Set foreground to green and background to gray for part of a line
+  `cecho --inline "{F_green}{B_grey}string to{reset} echo"`

--- a/cecho
+++ b/cecho
@@ -71,6 +71,9 @@ EXAMPLES:
   Set foreground to red and center in terminal
   $0 --centre --red "string to echo"
 
+  Set foreground to green and background to gray for part of a line
+  $0 --inline "{F_green}{B_grey}string to{reset} echo"
+
 EOF
 exit 0
 }

--- a/cecho
+++ b/cecho
@@ -68,7 +68,7 @@ EXAMPLES:
   Set the background to a specific colour
   $0 --background=170 "string to echo"
 
-  Set foreground to red and center in terminal.
+  Set foreground to red and center in terminal
   $0 --centre --red "string to echo"
 
 EOF

--- a/cecho
+++ b/cecho
@@ -187,9 +187,9 @@ function unescape_string() {
 
 function sub_inline_colour() {
   string="$@"
-  string=$(echo "$string" | sed -E "s/{F_([^}]+)}/\$\(colour_foreground \1\)/g")
-  string=$(echo "$string" | sed -E "s/{B_([^}]+)}/\$\(colour_background \1\)/g")
-  string=$(echo "$string" | sed -E "s/{reset}/\$\(colour reset)/g")
+  string=$(echo "$string" | sed -E "s/\{F_([^}]+)\}/\$\(colour_foreground \1\)/g")
+  string=$(echo "$string" | sed -E "s/\{B_([^}]+)\}/\$\(colour_background \1\)/g")
+  string=$(echo "$string" | sed -E "s/\{reset\}/\$\(colour reset)/g")
   string=$(echo "$string" | sed -E 's/"/\\\"/g')
   eval "echo \"${string}\"" | sed 's/{\ *}//g'
 }


### PR DESCRIPTION
On OSX, inline seems entirely broken. (I'm using GNU sed and triple checked to be sure that's what's being called within `cecho`, because my initial reaction to `sed` issues on OSX is always to assume it's a BSD/GNU difference). 

When I try and run `--inline`, here's what happens:

``` sh
$ cecho --inline "a"
sed: -e expression #1, char 41: Invalid preceding regular expression
sed: -e expression #1, char 41: Invalid preceding regular expression
sed: -e expression #1, char 28: Invalid preceding regular expression
```

The fix seems to be escaping `{` and `}` in `sub_inline_color` on lines 187-189. 
